### PR TITLE
Cuda patch

### DIFF
--- a/ext/MetaCUDAExt.jl
+++ b/ext/MetaCUDAExt.jl
@@ -97,7 +97,7 @@ function Fields.launch_foreachindex_global!(
             kernel = @cuda launch=false _foreachindex_global!(f, captured, itr[1])
             config = launch_configuration(kernel.fun; max_threads)
             Fields.KERNEL_CACHE[f_str] = config.threads
-            threads = compute_items(config.groupsize)
+            threads = compute_items(config.threads)
         else
             if haskey(Fields.KERNEL_CACHE, f_str)
                 threads = Fields.KERNEL_CACHE[f_str]
@@ -137,7 +137,7 @@ function Fields.launch_foreachindex_reduce_global!(
             ) 
             config = launch_configuration(kernel.fun; shmem=max_shmem, max_threads)
             # determine the launch configuration
-            threads = compute_items(config.groupsize)
+            threads = compute_items(config.threads)
             Fields.KERNEL_CACHE[f_str] = threads
         else
             if haskey(Fields.KERNEL_CACHE, f_str)

--- a/ext/MetaCUDAExt.jl
+++ b/ext/MetaCUDAExt.jl
@@ -165,6 +165,7 @@ end
 @inline Fields.groupidx() = blockIdx()
 @inline Fields.groupdim() = blockDim()
 @inline Fields.griddim() = gridDim()
-@inline Fields.groupreduce(op, val, neutral) = reduce_block(op, val, neutral)
+# Since this is currently only used for sum reductions, we can assume associativity (in exact arithmetic) and set shuffle = True
+@inline Fields.groupreduce(op, val, neutral) = reduce_block(op, val, neutral, #=shuffle=# Val(True))
 
 end


### PR DESCRIPTION
With these changes, the code runs on Pleiades (with CUDA GPUs on single node).

The first issue was that the field names of the object returned by `launch_configuration` differ between `AMDGPU.jl` and `CUDA.jl`. Namely, the corresponding CUDA versions of `groupsize` and `gridsize` are `threads` and `blocks`, respectively.

The second issue was that the `reduce_block` function takes four instead of three arguments under `CUDA.jl`. The additonal `shuffle` argument passed to `reduce_block` currently assumes that the reduction operation is associative in exact arithmetic (which is fine for now, since we only use it for sums as far as I can see).